### PR TITLE
UPDATED posting a new comment on a article if it exists along with some more error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -158,12 +158,13 @@ describe("POST /api/articles/:article_id/comments",()=>{
         .send(newComment)
         .expect(201)
         .then(({body})=>{
+            expect(body.comment.comment_id).toBe(19)
+            expect(body.comment.article_id).toBe(2)
+            expect(body.comment.author).toBe('lurker')
+            expect(body.comment.votes).toBe(0)
+            expect(body.comment.body).toBe('I cant code when i am sleepy.')
             expect(body.comment).toMatchObject({
-                comment_id: expect.any(Number),
-                article_id: expect.any(Number),
-                author: expect.any(String),
-                body: expect.any(String),
-                votes: expect.any(Number)
+                created_at: expect.any(String)
             })
         })
     })

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -31,10 +31,7 @@ exports.postArticleCommentById = (req, res, next) => {
     const article_id=req.params.article_id
     const {username,body}=req.body
 
-    Promise.all([checkArticleExists(article_id),checkUsersExists(username)])
-    .then((resolvedPromises)=>{
-        return insertArticleCommentById(article_id,username,body)
-    })
+    return insertArticleCommentById(article_id,username,body)
     .then((newComment)=>{
         res.status(201).send({comment:newComment})
     })

--- a/error-handlers/error-handler.js
+++ b/error-handlers/error-handler.js
@@ -7,6 +7,9 @@ exports.handlePsqlErrors=(err,req,res,next)=>{
     if(err.code==='22P02') {
         res.status(400).send({ msg: 'Bad Request' })
     }
+    else if(err.code==='23503') {
+        res.status(404).send({ msg: 'Not Found' })
+    }
     next(err)
 }
 exports.handleServerErrors = (err, req, res, next) => {


### PR DESCRIPTION

UPDATED 
ENDPOINT: /api/articles/:article_id/comments
METHOD: POST, STATUS: 201
adds a comment for an article.
Request body accepts an object with the following properties:
-username
-body
and responds with the newly posted comment.
ERROR HANDLING

username does not exist
article id does not exist
required field is missing
invalid type id