### PR TITLE
deletes a comment with the comment id passed and sends empty response back

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -276,3 +276,26 @@ describe("PATCH /api/articles/:article_id",()=>{
         });
     })
 })
+describe("DELETE /api/comments/:comment_id",()=>{
+    test("responds with status 204 and sends an empty response back after deleting the comment",()=>{
+        return request(app)
+        .delete('/api/comments/2')
+        .expect(204)
+    })
+    test("responds with status 404 and error message Not Found when an id does not exist",()=>{
+        return request(app)
+        .delete('/api/comments/999999')
+        .expect(404)
+        .then(({body})=>{
+            expect(body.msg).toBe("Not Found");
+        })
+    })
+    test("responds with status 400 and error message Bad Request when an invalid id given",()=>{
+        return request(app)
+        .delete('/api/comments/i_am_id')
+        .expect(400)
+        .then(({body})=>{
+            expect(body.msg).toBe("Bad Request");
+        })
+    })
+})

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require("express");
 const { getTopics, invalidRoutes, getEndpoints } = require("./controllers/topics.controllers");
 const { handleCustomErrors, handlePsqlErrors, handleServerErrors } = require("./error-handlers/error-handler");
 const { getArticleById, getArticles, getArticleCommentsById, postArticleCommentById, patchArticleById } = require("./controllers/articles.controllers");
+const { deleteCommentById } = require("./controllers/comments.controllers");
 
 const app = express();
 app.use(express.json())
@@ -13,6 +14,7 @@ app.get('/api/articles',getArticles)
 app.get('/api/articles/:article_id/comments',getArticleCommentsById)
 app.post('/api/articles/:article_id/comments',postArticleCommentById)
 app.patch('/api/articles/:article_id',patchArticleById)
+app.delete('/api/comments/:comment_id',deleteCommentById)
 
 app.get('*',invalidRoutes)
 

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,0 +1,10 @@
+const { removeCommentById } = require("../models/comments.models")
+
+exports.deleteCommentById = (req, res, next) => {
+    const comment_id = req.params.comment_id
+    removeCommentById(comment_id)
+    .then((results)=>{
+        res.status(204).send()
+    })
+    .catch(next)
+}

--- a/endpoints.json
+++ b/endpoints.json
@@ -102,5 +102,11 @@
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
     }
+  },
+  "DELETE /api/comments/:comment_id":{
+    "description": "serves with an empty response after deleting the comment",
+    "queries": [],
+    "requestBody": {},
+    "exampleResponse":{}
   }
 }

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -1,0 +1,12 @@
+const db = require('../db/connection')
+
+exports.removeCommentById = (comment_id) => {
+    return db.query(
+        `DELETE FROM comments WHERE comment_id = $1 RETURNING *;`,[comment_id]
+    )
+    .then(({rows})=>{
+        if(!rows.length){
+            return Promise.reject({ status:404, msg:"Not Found" })
+        }
+    })
+}


### PR DESCRIPTION
method: DELETE
status: 204
204 status does not sent any content back, just an empty response 
endpoint: /api/comments/:comment_id
description: deletes the comment that matches with the passed comment id
error handling : (1) id doesnt exist. (2) invalid id
