### PR TITLE
get article by id with comment count for that article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -77,7 +77,7 @@ describe("GET /api/articles/:article_id",()=>{
     });
 })
 describe("GET /api/articles",()=>{
-    test("responds with status 200 and an articles array of article objects including total articles' comments, excluding body, sorted by date in descending order",()=>{
+    test("responds with status 200 and an articles array of article objects including total articles' comments, excluding body, sorted by date in descending order and without comment_count",()=>{
         return request(app)
         .get('/api/articles')
         .expect(200)
@@ -94,6 +94,36 @@ describe("GET /api/articles",()=>{
                     created_at: expect.any(String),
                     comment_count: expect.any(Number),
                 })
+            })
+        })
+    })
+    test("responds with status 200 an article object of id provided with comment_count",()=>{
+        return request(app)
+        .get('/api/articles/1')
+        .expect(200)
+        .then(({body})=>{
+            expect(body.article).toHaveProperty('comment_count')
+            expect(body.article).toEqual(expect.objectContaining({
+                article_id: expect.any(Number),
+                title: expect.any(String),
+                topic: expect.any(String),
+                author: expect.any(String),
+                body: expect.any(String),
+                created_at: expect.any(String),
+                votes: expect.any(Number),
+                article_img_url: expect.any(String),
+                comment_count: expect.any(Number)
+            }))
+            expect(body.article).toEqual({
+                article_id: 1,
+                title: 'Living in the shadow of a great man',
+                topic: 'mitch',
+                author: 'butter_bridge',
+                body: 'I find this existence challenging',
+                created_at: '2020-07-09T20:11:00.000Z',
+                votes: 100,
+                article_img_url: 'https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700',
+                comment_count: 11
             })
         })
     })

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -2,7 +2,10 @@ const db = require('../db/connection')
 const format = require('pg-format')
 exports.fetchArticleById = (id) =>{
     return db.query(
-        `SELECT * FROM articles WHERE article_id = $1;`,[id]
+        `SELECT articles.*, COUNT(comments.article_id)::INT AS comment_count FROM articles 
+        LEFT JOIN comments ON comments.article_id = articles.article_id
+        WHERE articles.article_id = $1
+        GROUP BY articles.article_id`,[id]
     )
     .then((result)=>{
         if(result.rows.length===0){


### PR DESCRIPTION
method: GET 
status: 200
endpoint: /api/articles/:article_id

responds with an object of article with the article id passed and a property of comment count having total number of comments for that article